### PR TITLE
Cache Pug templates and track dependencies

### DIFF
--- a/pug/extension.js
+++ b/pug/extension.js
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto'
+
 import debugUtil from 'debug'
 import pug	from 'pug'
 
@@ -8,6 +10,12 @@ const debug 	= debugUtil('Eleventy:Plugins:Pug')
 const debugDev 	= debugUtil('Dev:Eleventy:Plugins:Pug')
 
 let cache = {}
+
+function getCacheKey(renderOptions, inputSource) {
+	const hash = createHash('md5')
+	hash.update(JSON.stringify({ renderOptions, inputSource }))
+	return hash.digest('hex')
+}
 
 const extension = {
 	outputFileExtension: 'html',
@@ -59,7 +67,7 @@ const extension = {
 			// `inputPath` is not enough as the plugin may render multiple
 			// parts of the same template, such as the permalink and the
 			// main content.
-			const key = JSON.stringify({ renderOptions, inputSource })
+			const key = getCacheKey(renderOptions, inputSource)
 			debugDev("Render key: %O", key)
 			const compiled = (cache[key] ??= pug.compile(inputSource, renderOptions))
 

--- a/pug/extension.js
+++ b/pug/extension.js
@@ -7,6 +7,7 @@ import DEFAULT_PUG_OPTIONS from './defaults.js'
 const debug 	= debugUtil('Eleventy:Plugins:Pug')
 const debugDev 	= debugUtil('Dev:Eleventy:Plugins:Pug')
 
+let cache = {}
 
 const extension = {
 	outputFileExtension: 'html',
@@ -15,6 +16,7 @@ const extension = {
 	async init() {
 		debug('Plugin initialized.')
 		debugDev('%O', this)
+		cache = {}
 	},
 
 	/**
@@ -36,39 +38,39 @@ const extension = {
 		// const filename = path.resolve('.', inputPath)
 		// debug('compile resolved inputPath to filename: %s', filename)
 
-		//	@TODO: Register Pug template dependencies for caching & performance
-		//	@see	https://www.11ty.dev/docs/languages/custom/#registering-dependencies
+		// Used to record dependencies after the fact.
+		const self = this
 
 		/** @param {Object} arg - Provided by Eleventy at runtime	*/
 		return async function(arg) {
-			debugDev('rendering... received arg: %O',		arg)
-			debug(	 'about to render... inputPath: %O', 	inputPath)
+			debug(	 'about to render... inputPath: %O',	inputPath)
 
-			//	TODO: clean up the setup and updating of options
-			const renderOptions = Object.assign(
-				{},
-				{
-					basedir: arg.eleventy.directories.includes,
-					filename: inputPath,
-					filters: extension.options.filters,
-				},
-				arg
-			)
+			// If we could get the `includes` in the outer function, we
+			// could call `compile` there and enable caching on the Eleventy
+			// side. We don’t set `cache: true` in the Pug options since we
+			// want to invalidate the cache ourselves on every build (see
+			// `init` above).
+			const renderOptions = {
+				basedir: arg.eleventy.directories.includes,
+				filename: inputPath,
+				filters: extension.options.filters,
+			}
 
-			// console.log('\n\nrenderOptions: %O\n\n', renderOptions)
+			// `inputPath` is not enough as the plugin may render multiple
+			// parts of the same template, such as the permalink and the
+			// main content.
+			const key = JSON.stringify({ renderOptions, inputSource })
+			debugDev("Render key: %O", key)
+			const compiled = (cache[key] ??= pug.compile(inputSource, renderOptions))
 
-			/*
-			 *	Using `pug.render()` is the simplest path to get this plugin working.
-			 *
-			 *	However:
-			 *		- `pug.compile()` returns a function that can be cached,
-			 *			_and_ that function has a `.dependencies` property!
-			 *
-			 *			- @see: `CustomEngine.getCompileCacheKey()`
-			 *			- would this actually speed up build times for large projects?
-			 */
-			return pug.render(inputSource, renderOptions)
+			const output = compiled(arg)
+			// See above about `includes`.
+			self.addDependencies(inputPath, output.dependencies)
+			return output
 		}
+	},
+	compileOptions: {
+		cache: false,
 	}
 }
 

--- a/pug/extension.js
+++ b/pug/extension.js
@@ -47,33 +47,28 @@ const extension = {
 		// debug('compile resolved inputPath to filename: %s', filename)
 
 		// Used to record dependencies after the fact.
-		const self = this
+		const renderOptions = {
+			basedir: this.config.directories.input,
+			filename: inputPath,
+			filters: extension.options.filters,
+		}
+
+		// We don’t set `cache: true` in the Pug options since we want to
+		// invalidate the cache ourselves on every build (see `init`
+		// above). Note that `inputPath` is not enough as the plugin may
+		// render multiple parts of the same template, such as the
+		// permalink and the main content.
+		const key = getCacheKey(renderOptions, inputSource)
+		debugDev("Render key: %O", key)
+		const compiled = (cache[key] ??= pug.compile(inputSource, renderOptions))
+		this.addDependencies(inputPath, compiled.dependencies)
+		debugDev("Dependencies of %s: %s", inputPath, compiled.dependencies)
 
 		/** @param {Object} arg - Provided by Eleventy at runtime	*/
 		return async function(arg) {
 			debug(	 'about to render... inputPath: %O',	inputPath)
 
-			// If we could get the `includes` in the outer function, we
-			// could call `compile` there and enable caching on the Eleventy
-			// side. We don’t set `cache: true` in the Pug options since we
-			// want to invalidate the cache ourselves on every build (see
-			// `init` above).
-			const renderOptions = {
-				basedir: arg.eleventy.directories.includes,
-				filename: inputPath,
-				filters: extension.options.filters,
-			}
-
-			// `inputPath` is not enough as the plugin may render multiple
-			// parts of the same template, such as the permalink and the
-			// main content.
-			const key = getCacheKey(renderOptions, inputSource)
-			debugDev("Render key: %O", key)
-			const compiled = (cache[key] ??= pug.compile(inputSource, renderOptions))
-
 			const output = compiled(arg)
-			// See above about `includes`.
-			self.addDependencies(inputPath, output.dependencies)
 			return output
 		}
 	},


### PR DESCRIPTION
Use `compile` instead of `render` and store the generated function in a cache that’s invalidated on every build. I don’t like putting `cache` at the top level of extension.js like this, but I don’t know what would be better.

The tests pass and I’ve had no problems on my blog. Anecdotally, this change slashed my build time from ~65 seconds to ~30 seconds. The biggest beneficiary went from:

```
Benchmark  10501ms  17%   419× (Aggregate) > Render Content > ./source/system/tag.pug (419 pages)
```

To:

```
Benchmark   2098ms   7%   419× (Aggregate) > Render Content > ./source/system/tag.pug (419 pages) +0ms
```

Closes #4 