### PR TITLE
Move pug render options to plugin init function

### DIFF
--- a/pug/extension.js
+++ b/pug/extension.js
@@ -44,18 +44,15 @@ const extension = {
 			debugDev('rendering... received arg: %O',		arg)
 			debug(	 'about to render... inputPath: %O', 	inputPath)
 
-			//	TODO: clean up the setup and updating of options
-			const renderOptions = Object.assign(
-				{},
-				{
-					basedir: arg.eleventy.directories.includes,
-					filename: inputPath,
-					filters: extension.options.filters,
-				},
-				arg
-			)
-
-			// console.log('\n\nrenderOptions: %O\n\n', renderOptions)
+		const renderOptions = Object.assign(
+			{},
+			extension.options,
+			{
+				basedir: arg.eleventy.directories.includes,
+				filename: inputPath,
+			},
+			arg
+		)
 
 			/*
 			 *	Using `pug.render()` is the simplest path to get this plugin working.

--- a/pug/index.js
+++ b/pug/index.js
@@ -27,7 +27,10 @@ export default function EleventyPluginPug(eleventyConfig, options = {}) {
 
 	// Prepare extension object
 	const PugExtension = EleventyPugExtension
-	PugExtension.options = Object.assign(PugExtension.options, options)
+	PugExtension.options = Object.assign(
+		PugExtension.options, 
+		{ filters: eleventyConfig.getFilters() },
+		options)
 
 	// PugExtension.options.basedir =
 	// 	options?.basedir


### PR DESCRIPTION
Moving the options initialization into the plugin function:

- allows respecting the options passed to the plugin via the `addPlugin(pugPlugin, { ...options })` call in `eleventy.config.js`
- makes filters available in templates without the need for additional configuration
- allows the plugin to work with zero configuration, e.g. `eleventyConfig.addPlugin(pugPlugin)`

This is especially useful in large projects, where options such as `cache: true` can be passed to the plugin depending on the current environment (production/development).