### PR TITLE
Universal filters for Haml

### DIFF
--- a/haml/hamlConfig.js
+++ b/haml/hamlConfig.js
@@ -13,13 +13,21 @@ module.exports = function (eleventyConfig, options = {}) {
 
 	// Remove eleventy specific things from `options`
 	let libraryOverride = options.eleventyLibraryOverride;
-	delete options.eleventyLibraryOverride;
+	delete options.eleventyLibraryOverride
+
+	const library = libraryOverride || haml;
+
+	for(let [name, callback] of Object.entries(eleventyConfig.getFilters())) {
+		library.filters[name] = function (string, buffer) {
+			return buffer.push(callback(string));
+		}
+	}
 
 	eleventyConfig.addTemplateFormats("haml");
 
 	eleventyConfig.addExtension("haml", {
 		compile: (str, inputPath) => {
-			return (libraryOverride || haml).compile(str);
+			return library.compile(str);
 		},
 	});
 };

--- a/haml/hamlConfig.js
+++ b/haml/hamlConfig.js
@@ -13,7 +13,7 @@ module.exports = function (eleventyConfig, options = {}) {
 
 	// Remove eleventy specific things from `options`
 	let libraryOverride = options.eleventyLibraryOverride;
-	delete options.eleventyLibraryOverride
+	delete options.eleventyLibraryOverride;
 
 	const library = libraryOverride || haml;
 

--- a/haml/test/haml-test.mjs
+++ b/haml/test/haml-test.mjs
@@ -56,6 +56,7 @@ test("HAML permalink (should be raw text)", async function () {
 });
 
 test('Haml built-in filter', async function () {
+	// Haml needs spaces for indents; tabs are a syntax error.
 	const template = `
 :cdata
   foo`;
@@ -68,4 +69,18 @@ test('Haml built-in filter', async function () {
 foo
 ]]>`;
 	strictEqual(result.content.trim(), expectedContent);
+});
+
+test('Eleventy built-in universal filter', async function () {
+	// Haml needs spaces for indents; tabs are a syntax error.
+	const template =`
+:slugify
+  My String
+`;
+
+	let [result] = await getTestResults((eleventyConfig) => {
+		eleventyConfig.addTemplate("sample.haml", template, {foo: 'bar'});
+	});
+
+	strictEqual(result.content.trim(), 'my-string');
 });

--- a/haml/test/haml-test.mjs
+++ b/haml/test/haml-test.mjs
@@ -12,93 +12,93 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 const input = path.relative(".", path.join(dirname, "stubs"));
 
 async function getTestResults(configCallback, options = {}) {
-	let elev = new Eleventy(input, undefined, {
-		config: (eleventyConfig) => {
-			eleventyConfig.addPlugin(HamlPlugin, options);
+  let elev = new Eleventy(input, undefined, {
+    config: (eleventyConfig) => {
+      eleventyConfig.addPlugin(HamlPlugin, options);
 
-			configCallback(eleventyConfig);
-		},
-	});
+      configCallback(eleventyConfig);
+    },
+  });
 
-	return await elev.toJSON();
+  return await elev.toJSON();
 }
 
 test("HAML standard template", async function () {
-	let [result] = await getTestResults((eleventyConfig) => {
-		eleventyConfig.addTemplate("sample.haml", "%p= name", {
-			name: "Zach",
-		});
-	});
+  let [result] = await getTestResults((eleventyConfig) => {
+    eleventyConfig.addTemplate("sample.haml", "%p= name", {
+      name: "Zach",
+    });
+  });
 
-	strictEqual(result.content.trim(), `<p>Zach</p>`);
+  strictEqual(result.content.trim(), `<p>Zach</p>`);
 });
 
 test("HAML library override", async function () {
-	let [result] = await getTestResults((eleventyConfig) => {
-		eleventyConfig.addTemplate("sample.haml", "%p= name", {
-			name: "Zach",
-		});
-	}, {
-		eleventyLibraryOverride: haml
-	});
+  let [result] = await getTestResults((eleventyConfig) => {
+    eleventyConfig.addTemplate("sample.haml", "%p= name", {
+      name: "Zach",
+    });
+  }, {
+    eleventyLibraryOverride: haml
+  });
 
-	strictEqual(result.content.trim(), `<p>Zach</p>`);
+  strictEqual(result.content.trim(), `<p>Zach</p>`);
 });
 
 test("HAML permalink (should be raw text)", async function () {
-	let [result] = await getTestResults((eleventyConfig) => {
-		eleventyConfig.addTemplate("sample.haml", "", {
-			permalink: "/this-is-a-url/"
-		});
-	});
+  let [result] = await getTestResults((eleventyConfig) => {
+    eleventyConfig.addTemplate("sample.haml", "", {
+      permalink: "/this-is-a-url/"
+    });
+  });
 
-	strictEqual(result.url, `/this-is-a-url/`);
+  strictEqual(result.url, `/this-is-a-url/`);
 });
 
 test('Haml built-in filter', async function () {
-	// Haml needs spaces for indents; tabs are a syntax error.
-	const template = `
+  // Haml needs spaces for indents; tabs are a syntax error.
+  const template = `
 :cdata
   foo`;
 
-	let [result] = await getTestResults((eleventyConfig) => {
-		eleventyConfig.addTemplate("sample.haml", template, {});
-	});
+  let [result] = await getTestResults((eleventyConfig) => {
+    eleventyConfig.addTemplate("sample.haml", template, {});
+  });
 
-	const expectedContent = `<![CDATA[
+  const expectedContent = `<![CDATA[
 foo
 ]]>`;
-	strictEqual(result.content.trim(), expectedContent);
+  strictEqual(result.content.trim(), expectedContent);
 });
 
 test('Eleventy built-in universal filter', async function () {
-	// Haml needs spaces for indents; tabs are a syntax error.
-	const template =`
+  // Haml needs spaces for indents; tabs are a syntax error.
+  const template =`
 :slugify
   My String
 `;
 
-	let [result] = await getTestResults((eleventyConfig) => {
-		eleventyConfig.addTemplate("sample.haml", template, {foo: 'bar'});
-	});
+  let [result] = await getTestResults((eleventyConfig) => {
+    eleventyConfig.addTemplate("sample.haml", template, {foo: 'bar'});
+  });
 
-	strictEqual(result.content.trim(), 'my-string');
+  strictEqual(result.content.trim(), 'my-string');
 });
 
 test('User-defined universal filter', async function () {
-	const myFilter = (string) => `FILTERED[${string}]`
-	const string = 'a string variable'
+  const myFilter = (string) => `FILTERED[${string}]`
+  const string = 'a string variable'
 
-	// Haml needs spaces for indents; tabs are a syntax error.
-	const template =`
+  // Haml needs spaces for indents; tabs are a syntax error.
+  const template =`
 :my_filter
   ${string}
 `;
 
-	let [result] = await getTestResults((eleventyConfig) => {
-		eleventyConfig.addFilter('my_filter', myFilter);
-		eleventyConfig.addTemplate("sample.haml", template, {foo: 'bar'});
-	});
+  let [result] = await getTestResults((eleventyConfig) => {
+    eleventyConfig.addFilter('my_filter', myFilter);
+    eleventyConfig.addTemplate("sample.haml", template, {foo: 'bar'});
+  });
 
-	strictEqual(result.content.trim(), myFilter(string));
+  strictEqual(result.content.trim(), myFilter(string));
 });

--- a/haml/test/haml-test.mjs
+++ b/haml/test/haml-test.mjs
@@ -54,3 +54,18 @@ test("HAML permalink (should be raw text)", async function () {
 
 	strictEqual(result.url, `/this-is-a-url/`);
 });
+
+test('Haml built-in filter', async function () {
+	const template = `
+:cdata
+  foo`;
+
+	let [result] = await getTestResults((eleventyConfig) => {
+		eleventyConfig.addTemplate("sample.haml", template, {});
+	});
+
+	const expectedContent = `<![CDATA[
+foo
+]]>`;
+	strictEqual(result.content.trim(), expectedContent);
+});

--- a/haml/test/haml-test.mjs
+++ b/haml/test/haml-test.mjs
@@ -84,3 +84,21 @@ test('Eleventy built-in universal filter', async function () {
 
 	strictEqual(result.content.trim(), 'my-string');
 });
+
+test('User-defined universal filter', async function () {
+	const myFilter = (string) => `FILTERED[${string}]`
+	const string = 'a string variable'
+
+	// Haml needs spaces for indents; tabs are a syntax error.
+	const template =`
+:my_filter
+  ${string}
+`;
+
+	let [result] = await getTestResults((eleventyConfig) => {
+		eleventyConfig.addFilter('my_filter', myFilter);
+		eleventyConfig.addTemplate("sample.haml", template, {foo: 'bar'});
+	});
+
+	strictEqual(result.content.trim(), myFilter(string));
+});


### PR DESCRIPTION
This provides access to Eleventy universal filters for Haml templates; see discussion at #32.